### PR TITLE
Fix potencial security vulnerability in Key CRD + added event recorder to controllers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.23 AS builder
+FROM golang:1.25 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ spec:
 
 ### Example CRD Usage: Creating a application key
 
-Creating keys with default permissions that will have access to bucket `my-b2-bucket` and will be saved to `new-key` secret in namespace `default`
+Creating keys with default permissions that will have access to bucket `my-b2-bucket` and will be saved to `new-key` secret in the namespace of creation
 ```yaml
 apiVersion: b2.issei.space/v1alpha2
 kind: Key
@@ -83,7 +83,6 @@ spec:
       - writeFiles
   writeConnectionSecretToRef:
       name: new-key
-      namespace: default
 ```
 The secret will contain `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `bucketName`, `endpoint`, `keyName`.
 

--- a/api/v1alpha2/key_types.go
+++ b/api/v1alpha2/key_types.go
@@ -26,8 +26,6 @@ import (
 type WriteConnectionSecretToRef struct {
 	// Set name of secret where credentials should be set
 	Name string `json:"name,omitempty"`
-	// Set namespace of secret where credentials should be set
-	Namespace string `json:"namespace,omitempty"`
 }
 
 // KeySpec defines the desired state of Key

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -162,19 +162,21 @@ func main() {
 	}
 
 	if err = (&controller.BucketReconciler{
-		Client:    mgr.GetClient(),
-		Log:       ctrl.Log.WithName("controller").WithName("Bucket"),
-		Scheme:    mgr.GetScheme(),
-		Backblaze: b2,
+		Client:        mgr.GetClient(),
+		Log:           ctrl.Log.WithName("controller").WithName("Bucket"),
+		Scheme:        mgr.GetScheme(),
+		Backblaze:     b2,
+		EventRecorder: mgr.GetEventRecorderFor("bucket-controller"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Bucket")
 		os.Exit(1)
 	}
 	if err = (&controller.KeyReconciler{
-		Client:    mgr.GetClient(),
-		Log:       ctrl.Log.WithName("controller").WithName("Key"),
-		Scheme:    mgr.GetScheme(),
-		Backblaze: b2,
+		Client:        mgr.GetClient(),
+		Log:           ctrl.Log.WithName("controller").WithName("Key"),
+		Scheme:        mgr.GetScheme(),
+		Backblaze:     b2,
+		EventRecorder: mgr.GetEventRecorderFor("key-controller"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Key")
 		os.Exit(1)

--- a/config/crd/bases/b2.issei.space_keys.yaml
+++ b/config/crd/bases/b2.issei.space_keys.yaml
@@ -91,10 +91,6 @@ spec:
                   name:
                     description: Set name of secret where credentials should be set
                     type: string
-                  namespace:
-                    description: Set namespace of secret where credentials should
-                      be set
-                    type: string
                 type: object
             type: object
           status:

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -12,10 +12,6 @@ namePrefix: b2operator-
 #commonLabels:
 #  someName: someValue
 
-bases:
-- ../crd
-- ../rbac
-- ../manager
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
 #- ../webhook
@@ -24,12 +20,11 @@ bases:
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
 #- ../prometheus
 # [METRICS] Expose the controller manager metrics service.
-- metrics_service.yaml
 
 # Uncomment the patches line if you enable Metrics, and/or are using webhooks and cert-manager
-patches:
 # [METRICS] The following patch will enable the metrics endpoint using HTTPS and the port :8443.
 # More info: https://book.kubebuilder.io/reference/metrics
+patches:
 - path: manager_metrics_patch.yaml
   target:
     kind: Deployment
@@ -45,31 +40,10 @@ patches:
 #- webhookcainjection_patch.yaml
 
 # the following config is for teaching kustomize how to do var substitution
-vars:
-# [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER' prefix.
-#- name: CERTIFICATE_NAMESPACE # namespace of the certificate CR
-#  objref:
-#    kind: Certificate
-#    group: cert-manager.io
-#    version: v1
-#    name: serving-cert # this name should match the one in certificate.yaml
-#  fieldref:
-#    fieldpath: metadata.namespace
-#- name: CERTIFICATE_NAME
-#  objref:
-#    kind: Certificate
-#    group: cert-manager.io
-#    version: v1
-#    name: serving-cert # this name should match the one in certificate.yaml
-#- name: SERVICE_NAMESPACE # namespace of the service
-#  objref:
-#    kind: Service
-#    version: v1
-#    name: webhook-service
-#  fieldref:
-#    fieldpath: metadata.namespace
-#- name: SERVICE_NAME
-#  objref:
-#    kind: Service
-#    version: v1
-#    name: webhook-service
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../crd
+- ../rbac
+- ../manager
+- metrics_service.yaml

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -59,6 +59,13 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
   - secrets
   verbs:
   - create

--- a/config/samples/b2_v1alpha2_key.yaml
+++ b/config/samples/b2_v1alpha2_key.yaml
@@ -16,6 +16,3 @@ spec:
       - listBuckets
       - readBuckets
       - listFiles
-  writeConnectionSecretToRef:
-      name: new-key
-      namespace: default

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/mgruszkiewicz/backblaze-operator
 
-go 1.23.3
-
-toolchain go1.23.7
+go 1.25.4
 
 require (
 	github.com/go-logr/logr v1.4.1

--- a/internal/controller/bucket_controller.go
+++ b/internal/controller/bucket_controller.go
@@ -23,9 +23,11 @@ import (
 	"github.com/go-logr/logr"
 	b2v1alpha2 "github.com/mgruszkiewicz/backblaze-operator/api/v1alpha2"
 	"github.com/mgruszkiewicz/go-backblaze"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -38,15 +40,17 @@ const bucketFinalizer = "bucket.b2.issei.space/finalizer"
 // BucketReconciler reconciles a Bucket object
 type BucketReconciler struct {
 	client.Client
-	Log       logr.Logger
-	Scheme    *runtime.Scheme
-	Backblaze *backblaze.B2
+	Log           logr.Logger
+	Scheme        *runtime.Scheme
+	Backblaze     *backblaze.B2
+	EventRecorder record.EventRecorder
 }
 
 //+kubebuilder:rbac:groups=b2.issei.space,resources=buckets,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=b2.issei.space,resources=buckets/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=b2.issei.space,resources=buckets/finalizers,verbs=update
 //+kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;create;update;patch;delete;watch
+//+kubebuilder:rbac:groups=core,resources=events,verbs=create;patch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
@@ -134,14 +138,31 @@ func (r *BucketReconciler) createOrUpdateBucket(ctx context.Context, bucket *b2v
 			// TODO: add `no_payment_history` handling in lib
 			if bucket_b2 == nil {
 				l.Info("unable to create bucket, no_payment_history?")
+				if r.EventRecorder != nil {
+					r.EventRecorder.Eventf(bucket, corev1.EventTypeWarning, "BucketCreationFailed",
+						"Failed to create bucket %s. Possible reason: no payment history. Please check your Backblaze account.", bucket.Name)
+				}
 			}
 
 			if bucket_err != nil {
+				if r.EventRecorder != nil {
+					r.EventRecorder.Eventf(bucket, corev1.EventTypeWarning, "BucketCreationFailed",
+						"Failed to create bucket %s: %v", bucket.Name, bucket_err)
+				}
 				return fmt.Errorf("unable to create Bucket: %v", bucket_err)
+			}
+
+			if bucket_b2 != nil && r.EventRecorder != nil {
+				r.EventRecorder.Eventf(bucket, corev1.EventTypeNormal, "BucketCreated",
+					"Successfully created bucket %s with ACL %s", bucket.Name, bucket.Spec.AtProvider.Acl)
 			}
 
 		} else {
 			l.Info("Bucket exist at provider, adopting")
+			if r.EventRecorder != nil {
+				r.EventRecorder.Eventf(bucket, corev1.EventTypeNormal, "BucketAdopted",
+					"Bucket %s already exists at provider and was adopted", bucket.Name)
+			}
 		}
 		bucket.Status.AtProvider = bucket.Spec.AtProvider
 		bucket.Status.Reconciled = true
@@ -168,9 +189,17 @@ func (r *BucketReconciler) createOrUpdateBucket(ctx context.Context, bucket *b2v
 
 			update_err := bucket_at_b2.UpdateAll(bucket_acl, make(map[string]string), bucket.Spec.AtProvider.BucketLifecycle, 0)
 			if update_err != nil {
+				if r.EventRecorder != nil {
+					r.EventRecorder.Eventf(bucket, corev1.EventTypeWarning, "BucketUpdateFailed",
+						"Failed to update bucket %s: %v", bucket.Name, update_err)
+				}
 				return fmt.Errorf("unable to update Bucket: %v", update_err)
 			} else {
 				bucket.Status.AtProvider = bucket.Spec.AtProvider
+				if r.EventRecorder != nil {
+					r.EventRecorder.Eventf(bucket, corev1.EventTypeNormal, "BucketUpdated",
+						"Successfully updated bucket %s", bucket.Name)
+				}
 			}
 			r.Status().Update(ctx, bucket)
 		}

--- a/internal/controller/key_controller.go
+++ b/internal/controller/key_controller.go
@@ -105,13 +105,13 @@ func (r *KeyReconciler) createKeySecret(ctx context.Context, key *b2v1alpha2.Key
 
 	// Check if secret exist
 	secret := &corev1.Secret{}
-	err := r.Get(context.TODO(), types.NamespacedName{Name: key.Spec.WriteConnectionSecretToRef.Name, Namespace: key.Spec.WriteConnectionSecretToRef.Namespace}, secret)
+	err := r.Get(context.TODO(), types.NamespacedName{Name: key.Spec.WriteConnectionSecretToRef.Name, Namespace: key.Namespace}, secret)
 	if err != nil {
 		l.Info("Not found existing secret... creating new")
 		secret = &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      key.Spec.WriteConnectionSecretToRef.Name,
-				Namespace: key.Spec.WriteConnectionSecretToRef.Namespace,
+				Namespace: key.Namespace,
 			},
 			Data: secretData,
 		}

--- a/internal/controller/key_controller.go
+++ b/internal/controller/key_controller.go
@@ -227,7 +227,7 @@ func (r *KeyReconciler) reconcileDelete(ctx context.Context, key *b2v1alpha2.Key
 		existing_secret := &corev1.Secret{}
 		if err := r.Client.Get(ctx, types.NamespacedName{
 			Name:      key.Spec.WriteConnectionSecretToRef.Name,
-			Namespace: key.Spec.WriteConnectionSecretToRef.Namespace},
+			Namespace: key.Namespace},
 			existing_secret,
 		); err != nil {
 			l.Info("Failed to get existing secret at cluster")

--- a/internal/controller/key_controller.go
+++ b/internal/controller/key_controller.go
@@ -30,6 +30,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -41,15 +42,17 @@ const keyFinalizer = "key.b2.issei.space/finalizer"
 // KeyReconciler reconciles a Key object
 type KeyReconciler struct {
 	client.Client
-	Log       logr.Logger
-	Scheme    *runtime.Scheme
-	Backblaze *backblaze.B2
+	Log           logr.Logger
+	Scheme        *runtime.Scheme
+	Backblaze     *backblaze.B2
+	EventRecorder record.EventRecorder
 }
 
 //+kubebuilder:rbac:groups=b2.issei.space,resources=keys,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=b2.issei.space,resources=keys/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=b2.issei.space,resources=keys/finalizers,verbs=update
 //+kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;create;update;patch;delete
+//+kubebuilder:rbac:groups=core,resources=events,verbs=create;patch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
@@ -93,6 +96,13 @@ func (r *KeyReconciler) reconcileCreate(ctx context.Context, key *b2v1alpha2.Key
 func (r *KeyReconciler) createKeySecret(ctx context.Context, key *b2v1alpha2.Key, appkey *backblaze.ApplicationKeyResponse) error {
 	l := log.FromContext(ctx)
 
+	// Determine secret name - use default if not specified
+	secretName := key.Spec.WriteConnectionSecretToRef.Name
+	if secretName == "" {
+		secretName = "b2-secret"
+		l.Info("WriteConnectionSecretToRef.Name not specified, using default secret name", "secretName", secretName)
+	}
+
 	// Secret data
 	secretData := map[string][]byte{
 		"bucketName": []byte(key.Spec.AtProvider.BucketName),
@@ -105,13 +115,13 @@ func (r *KeyReconciler) createKeySecret(ctx context.Context, key *b2v1alpha2.Key
 
 	// Check if secret exist
 	secret := &corev1.Secret{}
-	err := r.Get(ctx, types.NamespacedName{Name: key.Spec.WriteConnectionSecretToRef.Name, Namespace: key.Namespace}, secret)
+	err := r.Get(ctx, types.NamespacedName{Name: secretName, Namespace: key.Namespace}, secret)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			l.Info("Not found existing secret... creating new")
 			secret = &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      key.Spec.WriteConnectionSecretToRef.Name,
+					Name:      secretName,
 					Namespace: key.Namespace,
 				},
 				Data: secretData,
@@ -125,12 +135,12 @@ func (r *KeyReconciler) createKeySecret(ctx context.Context, key *b2v1alpha2.Key
 		return fmt.Errorf("failed to get secret: %w", err)
 	}
 
-	// Secret exists, update it
-	l.Info("Found existing secret with credentials, updating values")
-	secret.Data = secretData
-	if err := r.Update(ctx, secret); err != nil {
-		l.Error(err, "Unable to update existing secret with credentials")
-		return fmt.Errorf("failed to update secret: %w", err)
+	// Secret exists, skip overwriting
+	l.Info("Found existing secret, skipping overwrite to preserve existing data", "Secret.Namespace", secret.Namespace, "Secret.Name", secret.Name)
+	if r.EventRecorder != nil {
+		r.EventRecorder.Eventf(key, corev1.EventTypeWarning, "SecretAlreadyExists",
+			"Secret %s/%s already exists and was not overwritten to preserve existing data. If you want to update the secret, delete it first or use a different name.",
+			secret.Namespace, secret.Name)
 	}
 	return nil
 }
@@ -231,10 +241,16 @@ func (r *KeyReconciler) reconcileDelete(ctx context.Context, key *b2v1alpha2.Key
 	l.Info("Removing Key")
 
 	if deleteSecret {
+		// Determine secret name - use default if not specified
+		secretName := key.Spec.WriteConnectionSecretToRef.Name
+		if secretName == "" {
+			secretName = "b2-secret"
+		}
+
 		// Retriving existing secret
 		existing_secret := &corev1.Secret{}
 		if err := r.Client.Get(ctx, types.NamespacedName{
-			Name:      key.Spec.WriteConnectionSecretToRef.Name,
+			Name:      secretName,
 			Namespace: key.Namespace},
 			existing_secret,
 		); err != nil {

--- a/internal/controller/key_controller.go
+++ b/internal/controller/key_controller.go
@@ -90,7 +90,7 @@ func (r *KeyReconciler) reconcileCreate(ctx context.Context, key *b2v1alpha2.Key
 	return ctrl.Result{}, nil
 }
 
-func (r *KeyReconciler) createKeySecret(ctx context.Context, key *b2v1alpha2.Key, appkey *backblaze.ApplicationKeyResponse) *corev1.Secret {
+func (r *KeyReconciler) createKeySecret(ctx context.Context, key *b2v1alpha2.Key, appkey *backblaze.ApplicationKeyResponse) error {
 	l := log.FromContext(ctx)
 
 	// Secret data
@@ -105,26 +105,34 @@ func (r *KeyReconciler) createKeySecret(ctx context.Context, key *b2v1alpha2.Key
 
 	// Check if secret exist
 	secret := &corev1.Secret{}
-	err := r.Get(context.TODO(), types.NamespacedName{Name: key.Spec.WriteConnectionSecretToRef.Name, Namespace: key.Namespace}, secret)
+	err := r.Get(ctx, types.NamespacedName{Name: key.Spec.WriteConnectionSecretToRef.Name, Namespace: key.Namespace}, secret)
 	if err != nil {
-		l.Info("Not found existing secret... creating new")
-		secret = &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      key.Spec.WriteConnectionSecretToRef.Name,
-				Namespace: key.Namespace,
-			},
-			Data: secretData,
+		if errors.IsNotFound(err) {
+			l.Info("Not found existing secret... creating new")
+			secret = &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      key.Spec.WriteConnectionSecretToRef.Name,
+					Namespace: key.Namespace,
+				},
+				Data: secretData,
+			}
+			if err := r.Create(ctx, secret); err != nil {
+				l.Error(err, "Failed to create new Secret", "Secret.Namespace", secret.Namespace, "Secret.Name", secret.Name)
+				return fmt.Errorf("failed to create secret: %w", err)
+			}
+			return nil
 		}
-	} else {
-		l.Info("Found existing secret with credentials, updating values")
-		secret.Data = secretData
-		err = r.Update(context.TODO(), secret)
-		if err != nil {
-			l.Error(err, "Unable to update existing secret with credentials")
-		}
-
+		return fmt.Errorf("failed to get secret: %w", err)
 	}
-	return secret
+
+	// Secret exists, update it
+	l.Info("Found existing secret with credentials, updating values")
+	secret.Data = secretData
+	if err := r.Update(ctx, secret); err != nil {
+		l.Error(err, "Unable to update existing secret with credentials")
+		return fmt.Errorf("failed to update secret: %w", err)
+	}
+	return nil
 }
 
 func (r *KeyReconciler) createOrUpdateKey(ctx context.Context, key *b2v1alpha2.Key) error {
@@ -178,9 +186,9 @@ func (r *KeyReconciler) createOrUpdateKey(ctx context.Context, key *b2v1alpha2.K
 
 		if applicationKeyCreate.ApplicationKeyId != "" {
 			l.Info("Got application key id from provider, creating secret")
-			secret := r.createKeySecret(ctx, key, applicationKeyCreate)
-			if err := r.Create(ctx, secret); err != nil {
-				l.Error(err, "Failed to create new Secret", "Secret.Namespace", secret.Namespace, "Deployment.Name", secret.Name)
+			if err := r.createKeySecret(ctx, key, applicationKeyCreate); err != nil {
+				l.Error(err, "Failed to create or update Secret")
+				return err
 			}
 		}
 


### PR DESCRIPTION
* **Breaking change**: resolved https://github.com/mgruszkiewicz/backblaze-operator/issues/13 by removing `namespace` field from `writeConnectionSecretToRef` in Key CRD. Now the secrets will be always created in the same namespace as the CR.
* Fixed default `writeConnectionSecretToRef.name` - now the secret will be by default named `b2-secret` if no name is specified by the user.
* Added event recorder, bucket and key controllers will add informations to `event` fields in each CR to better indicate the status.